### PR TITLE
Generate release APK and capture as workflow artifact

### DIFF
--- a/.github/workflows/android-master.yml
+++ b/.github/workflows/android-master.yml
@@ -21,8 +21,13 @@ jobs:
       run: ./gradlew test --stacktrace
     - name: Build with Gradle
       run: ./gradlew build --stacktrace
-    - name: Upload APK
+    - name: Upload debug APK
       uses: actions/upload-artifact@v1
       with:
-        name: karuna-app
+        name: karuna-debug-app
         path: app/build/outputs/apk/debug/app-debug.apk
+    - name: Upload release APK
+      uses: actions/upload-artifact@v1
+      with:
+        name: karuna-release-app
+        path: app/build/outputs/apk/release/app-release-unsigned.apk


### PR DESCRIPTION
Since Google Playstore manage the signing part for us and we can upload the unsigned release APK via authorised Google Playstore, we are only generating the unsigned APK as a part of CI. This will also save us from securing the Keystore file and Keystore file credentials.